### PR TITLE
fix: sort memory results by priority and recency

### DIFF
--- a/src/agentic_workflow/memory/manager.py
+++ b/src/agentic_workflow/memory/manager.py
@@ -247,8 +247,8 @@ class MemoryManager:
                         logger.warning(f"Failed to query store {store_name}: {e}")
                         continue
 
-                # Sort merged results by priority and timestamp
-                all_results.sort(key=lambda e: (-e.priority, e.timestamp), reverse=True)
+                # Sort merged results by priority and timestamp (highest priority, most recent first)
+                all_results.sort(key=lambda e: (e.priority, e.timestamp), reverse=True)
 
                 # Apply limit
                 limited_results = all_results[: query.limit]


### PR DESCRIPTION
## Summary
- ensure memory retrieval sorts by priority and timestamp descending so important, recent entries appear first

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68944228091c8326924737f275cf8d22