### PR TITLE
docs: document store runtime error in memory manager

### DIFF
--- a/src/agentic_workflow/memory/manager.py
+++ b/src/agentic_workflow/memory/manager.py
@@ -159,6 +159,7 @@ class MemoryManager:
 
         Raises:
             ValueError: If store is not available
+            RuntimeError: If storing the entry fails
         """
         try:
             # Generate ID if not provided


### PR DESCRIPTION
## Summary
- document that `store` may raise `RuntimeError` when entry persistence fails

## Testing
- `pre-commit run --files src/agentic_workflow/memory/manager.py` *(fails: missing type stubs like `pydantic`, `langchain_openai`, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68944243170c8326b1968aeaaf63969f