### PR TITLE
docs(core): clarify log_performance metadata parameter

### DIFF
--- a/src/agentic_workflow/core/logging_config.py
+++ b/src/agentic_workflow/core/logging_config.py
@@ -223,7 +223,8 @@ def log_performance(operation: str, duration: float, **metadata: Any) -> None:
     Args:
     operation: Name of the operation
     duration: Duration in seconds
-    **"""
+    metadata: Additional metadata to include in the log
+    """
     logger = get_logger("performance")
 
     logger.info_with_data(  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- fix stray placeholder in log_performance docstring
- document metadata argument for clearer logging API

## Testing
- `SKIP=black,isort pre-commit run --files src/agentic_workflow/core/logging_config.py` *(fails: missing pydantic stubs and other dependencies)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68944236185c8326a083a253fd2774cd